### PR TITLE
Added a link to hosted docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,16 @@
 					<li>
 						<div class="group row">
 							<div class="col-1">
+								<p>Read the Tweepy documentation</p>
+							</div>
+							<div class="col-2">
+								<p class="button"><a href="http://packages.python.org/tweepy/html/" target="_blank">Tweepy Documentation</a></p>
+							</div>
+						</div>
+					</li>
+					<li>
+						<div class="group row">
+							<div class="col-1">
 								<p>Look over the Twitter API documentation and keep it close by! It's a valuable resource.</p>
 							</div>
 							<div class="col-2">


### PR DESCRIPTION
I managed to fail to find http://packages.python.org/tweepy/html/ for far too long. Obviously this may just be me, but it seems reasonable to add the link...!
